### PR TITLE
Improve renaming helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,15 @@ On some READMEs, you may see small images that convey metadata, such as whether 
 Depending on what you are making, it can be a good idea to include screenshots or even a video (you'll frequently see GIFs rather than actual videos). Tools like ttygif can help, but check out Asciinema for a more sophisticated method.
 
 ## Installation
-Within a particular ecosystem, there may be a common way of installing things, such as using Yarn, NuGet, or Homebrew. However, consider the possibility that whoever is reading your README is a novice and would like more guidance. Listing specific steps helps remove ambiguity and gets people to using your project as quickly as possible. If it only runs in a specific context like a particular programming language version or operating system or has dependencies that have to be installed manually, also add a Requirements subsection.
+
+Ces outils nécessitent Python 3 et quelques dépendances. Installez-les avec :
+
+```bash
+pip install pandas numpy scipy matplotlib neurokit2 mido
+```
+
+Toutes les commandes présentées dans ce document doivent être exécutées depuis
+la racine du projet afin que les chemins relatifs fonctionnent correctement.
 
 ## Usage
 Use examples liberally, and show the expected output if you can. It's helpful to have inline the smallest example of usage that you can demonstrate, while providing links to more sophisticated examples if they are too long to reasonably include in the README.
@@ -118,3 +126,45 @@ The command creates one PNG per sequence under
 `id_participant,numero_sequence,timestamp,eda_value` table to `merged.csv` and
 a `features.csv` file containing EDA statistics for each sequence (mean,
 median, number of peaks, etc.).
+
+## Basic EDA feature extraction
+
+The repository also provides `scripts/extract_eda_features.py` to compute
+overall EDA statistics for each JSON file independently. It scans a directory
+of Embrace JSON exports and writes a summary CSV with phasic features.
+
+Example:
+
+```bash
+python3 scripts/extract_eda_features.py json/ generated_data/eda_features.csv
+```
+
+Par exemple, si vos JSON sont placés dans un dossier
+`creme_donnees_expes_montres`, lancez :
+
+```bash
+python3 scripts/extract_eda_features.py creme_donnees_expes_montres/ \
+    generated_data/eda_features.csv
+```
+
+The output lists one row per JSON file with metrics such as mean phasic EDA,
+area under the curve and number of SCR peaks.
+
+## Renaming EDA JSON files
+
+Some datasets store the EDA exports with filenames based on the watch
+identifier (the ``participantID`` field). To use these files with
+`match_eda.py`, their names must match the ``id_participant`` values
+found in ``detections.csv``. If you have a CSV mapping ``participantID``
+to ``id_participant`` (for instance the file ``correspondanceIdNom.csv``
+exported from Embrace), you can automate this step.  The mapping may
+either provide explicit headers or simply list four columns where the
+third one contains the watch ID and the fourth one the hashed
+``id_participant``:
+
+```bash
+python3 scripts/rename_eda_files.py json/ correspondanceIdNom.csv --output renamed_json/
+```
+
+The command will create ``renamed_json/<id_participant>.json`` for each
+file, ready to be processed by ``match_eda.py``.

--- a/scripts/extract_eda_features.py
+++ b/scripts/extract_eda_features.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""Extract basic EDA features from JSON files.
+
+This helper processes all ``*.json`` files inside the given directory and
+writes a CSV summary with phasic EDA statistics for each file. It is a
+standalone version of the feature extraction used in ``match_eda.py``.
+"""
+
+import argparse
+import json
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import neurokit2 as nk
+from scipy import integrate
+from scipy.stats import kurtosis, skew
+
+
+def load_eda_json(path: Path) -> tuple[list[float], float]:
+    """Return EDA values and sampling rate from an Embrace JSON file."""
+    with path.open(encoding="utf-8") as f:
+        data = json.load(f)
+
+    # some exports wrap the payload in a single-item list
+    if isinstance(data, list):
+        data = data[0]
+
+    if "rawData" in data and "eda" in data["rawData"]:
+        eda = data["rawData"]["eda"]
+    elif "eda" in data:
+        eda = data["eda"]
+    else:
+        raise KeyError("Cannot find EDA data in JSON")
+
+    values = [v for v in eda.get("values", []) if isinstance(v, (int, float))]
+    if not values:
+        raise ValueError("no EDA values")
+    sampling_rate = eda.get("samplingFrequency", 0)
+    return values, float(sampling_rate)
+
+
+def compute_features(values: list[float], sampling_rate: float) -> dict:
+    """Return phasic EDA features for a signal."""
+    resampled = nk.signal_resample(values, sampling_rate=sampling_rate, desired_sampling_rate=8)
+    signals, _ = nk.eda_process(resampled, sampling_rate=8)
+    phasic = signals["EDA_Phasic"]
+    scr_amp = signals["SCR_Amplitude"]
+
+    return {
+        "EDA Phasic Mean": float(np.mean(phasic)),
+        "EDA Phasic Median": float(np.median(phasic)),
+        "EDA Phasic STD": float(np.std(phasic)),
+        "EDA Phasic Number of Peaks": int(np.nansum(signals["SCR_Peaks"])),
+        "EDA Phasic AUC": float(integrate.trapz(phasic)),
+        "EDA Phasic Max Amplitudes": float(np.nanmax(scr_amp)),
+        "EDA Phasic Sum Amplitudes": float(np.nansum(scr_amp)),
+        "EDA Phasic Mean Amplitudes": float(np.nanmean(scr_amp)),
+        "EDA Phasic Kurtosis": float(kurtosis(phasic)),
+        "EDA Phasic Skewness": float(skew(phasic)),
+    }
+
+
+def process_directory(directory: Path) -> pd.DataFrame:
+    rows = []
+    for json_file in sorted(directory.rglob("*.json")):
+        try:
+            values, sr = load_eda_json(json_file)
+        except Exception as e:
+            print(f"Skipping {json_file.name}: {e}")
+            continue
+        if len(values) < 10:
+            print(f"Skipping {json_file.name}: too few values")
+            continue
+        feats = compute_features(values, sr)
+        feats["filename"] = json_file.name
+        rows.append(feats)
+        print(f"Processed {json_file.name}")
+    return pd.DataFrame(rows)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Compute EDA features for each JSON file")
+    parser.add_argument("eda_dir", type=Path, help="Directory containing JSON files")
+    parser.add_argument("output_csv", type=Path, nargs="?", default=Path("generated_data/eda_features.csv"), help="Where to save the CSV summary")
+    args = parser.parse_args()
+
+    df = process_directory(args.eda_dir)
+    args.output_csv.parent.mkdir(parents=True, exist_ok=True)
+    df.to_csv(args.output_csv, index=False)
+    print(f"Wrote {len(df)} rows to {args.output_csv}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/rename_eda_files.py
+++ b/scripts/rename_eda_files.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""Rename EDA JSON files according to a mapping.
+
+This helper scans a directory of Embrace JSON exports, reads the
+``participantID`` field from each file and renames (or copies) the file
+so that its name matches the ``id_participant`` used in ``detections.csv``.
+
+The mapping CSV must provide the watch identifier (``participantID``)
+and the corresponding ``id_participant`` used in ``detections.csv``.
+It may contain additional columns or omit the header entirely. In that
+case the third and fourth columns are assumed to be
+``participantID`` and ``id_participant``.
+
+Example:
+    python3 scripts/rename_eda_files.py json/ mapping.csv --output renamed_json/
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import shutil
+from pathlib import Path
+
+
+def load_mapping(path: Path) -> dict[str, str]:
+    """Return a dictionary ``{participantID -> id_participant}``.
+
+    The CSV may either provide explicit ``participantID`` and
+    ``id_participant`` headers or be headerless (e.g. the Embrace export
+    ``correspondanceIdNom.csv``). In the latter case the function uses the
+    third and fourth columns.
+    """
+    with path.open(newline="", encoding="utf-8-sig") as f:
+        rows = list(csv.reader(f))
+
+    if not rows:
+        return {}
+
+    header = [c.strip() for c in rows[0]]
+    if "participantID" in header and "id_participant" in header:
+        pid_idx = header.index("participantID")
+        id_idx = header.index("id_participant")
+        data_rows = rows[1:]
+    else:
+        pid_idx = 2
+        id_idx = 3
+        data_rows = rows
+
+    mapping: dict[str, str] = {}
+    for row in data_rows:
+        if len(row) <= max(pid_idx, id_idx):
+            continue
+        pid = row[pid_idx].strip()
+        target = row[id_idx].strip()
+        if pid and target:
+            mapping[pid] = target
+    return mapping
+
+
+def get_participant_id(json_path: Path) -> str | None:
+    """Extract participantID from a JSON file."""
+    with json_path.open(encoding="utf-8") as f:
+        data = json.load(f)
+    if isinstance(data, list):
+        data = data[0]
+    return data.get("participantID") or data.get("rawData", {}).get("participantID")
+
+
+def process(json_dir: Path, mapping: dict[str, str], out_dir: Path, copy: bool) -> None:
+    out_dir.mkdir(parents=True, exist_ok=True)
+    for json_file in json_dir.glob("*.json"):
+        pid = get_participant_id(json_file)
+        if pid is None:
+            print(f"Skipping {json_file.name}: missing participantID")
+            continue
+        target = mapping.get(pid)
+        if not target:
+            print(f"No mapping for participantID {pid}, leaving name unchanged")
+            target_name = json_file.name
+        else:
+            target_name = f"{target}.json"
+        dest = out_dir / target_name
+        if copy:
+            shutil.copy2(json_file, dest)
+        else:
+            json_file.rename(dest)
+        print(f"-> {dest}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Rename EDA JSON files using a mapping CSV")
+    parser.add_argument("json_dir", type=Path, help="Directory containing original JSON files")
+    parser.add_argument("mapping_csv", type=Path, help="CSV mapping participantID to id_participant")
+    parser.add_argument("--output", type=Path, default=None, help="Directory to place renamed files (defaults to in-place)")
+    parser.add_argument("--copy", action="store_true", help="Copy instead of renaming")
+    args = parser.parse_args()
+
+    out_dir = args.output if args.output is not None else args.json_dir
+    mapping = load_mapping(args.mapping_csv)
+    process(args.json_dir, mapping, out_dir, args.copy)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- make `rename_eda_files.py` accept headerless mapping CSVs
- document the mapping format with an example in the README

## Testing
- `python -m py_compile scripts/extract_eda_features.py scripts/match_eda.py scripts/build_detection_csv.py scripts/plot_eda_sessions.py scripts/rename_eda_files.py`

------
https://chatgpt.com/codex/tasks/task_e_684e953a8630832c9414eb7c3f4c0144