### PR TITLE
Fix usage docstring and ignore py cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+# Ignore Python cache files
+__pycache__/
+*.pyc
+
+# Ignore virtual environment
+.venv/

--- a/scripts/build_png_plts.py
+++ b/scripts/build_png_plts.py
@@ -2,10 +2,11 @@
 """Génère un PNG par séquence EDA pour chaque participant.
 
 Usage :
-    python build_png_plots.py time_all_trials.csv eda_samples.csv plots_dir
+    python build_png_plts.py time_all_trials.csv eda_samples.csv plots_dir
 """
 from __future__ import annotations
-import argparse, csv, sys
+import argparse
+import sys
 from pathlib import Path
 
 import pandas as pd


### PR DESCRIPTION
## Summary
- correct script name in build_png_plts usage example
- add .gitignore to avoid committing caches and virtual env
- remove unused csv import

## Testing
- `python -m py_compile scripts/*.py`


------
https://chatgpt.com/codex/tasks/task_e_68503c6bbd18832ca310ad394843e079